### PR TITLE
Mark o final

### DIFF
--- a/draft-ietf-tls-sni-encryption.md
+++ b/draft-ietf-tls-sni-encryption.md
@@ -262,7 +262,10 @@ MITM attack is troubling.
 
 There are other classes of solutions in which the master secret is verified by
 verifying a certificate provided by the protected service. These solutions offer
-more protection against a Man-In-The-Middle attack by the fronting service.
+more protection against a Man-In-The-Middle attack by the fronting service. The
+downside is the the client will not verify the identity of the fronting service
+with risks discussed in {#frontingspoofing}, but solutions will have to
+mitigate this risks. Overall, end-to-end TLS to the protected service is preferable.
 
 The fronting service could be pressured
 by adversaries. By design, it could be forced to deny access to
@@ -459,7 +462,7 @@ approach was first proposed in a message to that list:
 https://mailarchive.ietf.org/arch/msg/tls/tXvdcqnogZgqmdfCugrV8M90Ftw.
 
 Thanks to Daniel Kahn Gillmor for a pretty detailed review of the 
-initial draft. Thanks to Stephen Farrell, Mark Orchezowski, Martin Rex
-and Martin Thomson for their reviews.
+initial draft. Thanks to Stephen Farrell, Martin Rex
+Martin Thomson and employees of the UK National Cyber Security Centre for their reviews.
 
 {backmatter}


### PR DESCRIPTION
Two sets of comments from Mark O, received after WGLC. One is a reference to the acknowledgement section, in which he would rather not see his name spelled out. The other is about residual risks of fronting server spoofing when only the hidden service is verified in TLS.