### PR TITLE
Fix fronting spoofing ref

### DIFF
--- a/draft-ietf-tls-sni-encryption.md
+++ b/draft-ietf-tls-sni-encryption.md
@@ -268,7 +268,8 @@ verifying a certificate provided by the protected service. These solutions offer
 more protection against a Man-In-The-Middle attack by the fronting service. The
 downside is that the client will not verify the identity of the fronting service,
 which enables fronting server spoofing attacks such as the "honeypot" attack
-discussed below. Overall, end-to-end TLS to the protected service is preferable.
+discussed below. Overall, end-to-end TLS to the protected service is preferable,
+but it is important to also provide a way to authenticate the fronting service.
 
 The fronting service could be pressured by adversaries. 
 By design, it could be forced to deny access to

--- a/draft-ietf-tls-sni-encryption.md
+++ b/draft-ietf-tls-sni-encryption.md
@@ -266,9 +266,9 @@ MITM attack is troubling.
 There are other classes of solutions in which the master secret is verified by
 verifying a certificate provided by the protected service. These solutions offer
 more protection against a Man-In-The-Middle attack by the fronting service. The
-downside is the the client will not verify the identity of the fronting service
-with risks discussed in {#frontingspoofing}, but solutions will have to
-mitigate this risks. Overall, end-to-end TLS to the protected service is preferable.
+downside is the the client will not verify the identity of the fronting service,
+which enables fronting server spoofing attacks such as the "honeypot" attack
+discussed below. Overall, end-to-end TLS to the protected service is preferable.
 
 The fronting service could be pressured by adversaries. 
 By design, it could be forced to deny access to

--- a/draft-ietf-tls-sni-encryption.md
+++ b/draft-ietf-tls-sni-encryption.md
@@ -266,7 +266,7 @@ MITM attack is troubling.
 There are other classes of solutions in which the master secret is verified by
 verifying a certificate provided by the protected service. These solutions offer
 more protection against a Man-In-The-Middle attack by the fronting service. The
-downside is the the client will not verify the identity of the fronting service,
+downside is that the client will not verify the identity of the fronting service,
 which enables fronting server spoofing attacks such as the "honeypot" attack
 discussed below. Overall, end-to-end TLS to the protected service is preferable.
 


### PR DESCRIPTION
The delayed merge of PR#27 left a dangling reference in the markdown source. This is an attempt to fix the issue.